### PR TITLE
extended field setter for hierarchical operation

### DIFF
--- a/src/test/java/com/tngtech/configbuilder/ConfigBuilderExtensionIntegrationTest.java
+++ b/src/test/java/com/tngtech/configbuilder/ConfigBuilderExtensionIntegrationTest.java
@@ -1,0 +1,33 @@
+package com.tngtech.configbuilder;
+
+import com.tngtech.configbuilder.testclasses.ExtendedTestConfig;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class ConfigBuilderExtensionIntegrationTest {
+
+    private ExtendedTestConfig config;
+
+    @Before
+    public void setUp() {
+        config = new ConfigBuilder<ExtendedTestConfig>(ExtendedTestConfig.class).build();
+    }
+
+    @Test
+    public void testGetValuePresentInSuperClassAndCurrentClass() {
+        assertThat(config.getSomeNumber(), is(5));
+    }
+
+    @Test
+    public void testGetValueFromSuperclass() {
+        assertThat(config.getSuperSomeNumber(), is(3));
+    }
+
+    @Test
+    public void testDirectValue() {
+        assertThat(config.getAdditionalNumber(), is(4));
+    }
+}

--- a/src/test/java/com/tngtech/configbuilder/ConfigBuilderIntegrationTest.java
+++ b/src/test/java/com/tngtech/configbuilder/ConfigBuilderIntegrationTest.java
@@ -12,8 +12,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
 import java.io.PrintStream;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -31,15 +29,17 @@ public class ConfigBuilderIntegrationTest {
 
     private Class configClass;
     private Object configInstance;
+    private PrintStream originalOutStream;
 
     @Before
     public void setUp() {
+        originalOutStream = new PrintStream(System.out);
         System.setOut(new PrintStream(outContent));
     }
 
     @After
     public void tearDown() {
-        System.setOut(null);
+        System.setOut(originalOutStream);
     }
 
     @Parameterized.Parameters

--- a/src/test/java/com/tngtech/configbuilder/ConfigBuilderTest.java
+++ b/src/test/java/com/tngtech/configbuilder/ConfigBuilderTest.java
@@ -64,10 +64,12 @@ public class ConfigBuilderTest {
     private Properties properties;
     @Mock
     private LoadingOrder loadingOrder;
+    private PrintStream originalOutStream;
 
     @Before
     public void setUp() throws Exception {
 
+        originalOutStream = new PrintStream(System.out);
         System.setOut(new PrintStream(outContent));
 
         when(configBuilderFactory.getInstance(BuilderConfiguration.class)).thenReturn(builderConfiguration);
@@ -85,7 +87,7 @@ public class ConfigBuilderTest {
 
     @After
     public void tearDown() {
-        System.setOut(null);
+        System.setOut(originalOutStream);
     }
 
     @Test

--- a/src/test/java/com/tngtech/configbuilder/testclasses/ExtendedTestConfig.java
+++ b/src/test/java/com/tngtech/configbuilder/testclasses/ExtendedTestConfig.java
@@ -1,0 +1,27 @@
+package com.tngtech.configbuilder.testclasses;
+
+import com.tngtech.configbuilder.annotation.valueextractor.DefaultValue;
+import com.tngtech.configbuilder.annotation.valueextractor.ImportedValue;
+
+public class ExtendedTestConfig extends TestConfig {
+    @DefaultValue("4")
+    @ImportedValue("additionalNumber")
+    private int additionalNumber;
+
+    @DefaultValue("5")
+    @ImportedValue("someNumber")
+    private int someNumber;
+
+    public int getAdditionalNumber() {
+        return additionalNumber;
+    }
+
+    @Override
+    public Integer getSomeNumber() {
+        return someNumber;
+    }
+    
+    public Integer getSuperSomeNumber() {
+        return super.getSomeNumber();
+    }
+}

--- a/src/test/java/com/tngtech/configbuilder/testclasses/TestConfig.java
+++ b/src/test/java/com/tngtech/configbuilder/testclasses/TestConfig.java
@@ -87,6 +87,10 @@ public class TestConfig {
     public void setSomeNumber(Integer someNumber) {
         this.someNumber = someNumber;
     }
+  
+    public Integer getSomeNumber() {
+      return someNumber;
+    }
 
     public void setSomeString(String someString) {
         this.someString = someString;
@@ -137,7 +141,7 @@ public class TestConfig {
     }
 
     @Validation
-    private void validate() {
+    protected void validate() {
         System.out.println("config validated");
     }
 }

--- a/src/test/java/com/tngtech/configbuilder/util/FieldSetterTest.java
+++ b/src/test/java/com/tngtech/configbuilder/util/FieldSetterTest.java
@@ -32,6 +32,11 @@ public class FieldSetterTest {
         public String testString = "defaultValue";
     }
 
+    private static class ExtendedTestConfig extends TestConfig {
+        @DefaultValue("stringValue")
+        public String extendedTestString;
+    }
+
     private static class TestConfigForIllegalArgumentException {
         @DefaultValue("user")
         public int testInt;
@@ -91,8 +96,8 @@ public class FieldSetterTest {
 
         fieldSetter.setFields(testConfig, builderConfiguration);
 
-        assertEquals("stringValue",testConfig.testString);
-        assertEquals("stringValue",testConfig.emptyTestString);
+        assertEquals("stringValue", testConfig.testString);
+        assertEquals("stringValue", testConfig.emptyTestString);
 
     }
 
@@ -107,5 +112,20 @@ public class FieldSetterTest {
         fieldSetter.setFields(testConfigWithoutAnnotations, builderConfiguration);
 
         assertEquals("testString", testConfigWithoutAnnotations.testString);
+    }
+
+    @Test
+    public void testSetFieldsInObjectHierarchy() {
+        when(fieldValueExtractor.extractValue(Matchers.any(Field.class), Matchers.any(BuilderConfiguration.class))).thenReturn("stringValue");
+        when(fieldValueTransformer.transformFieldValue(Matchers.any(Field.class), Matchers.any(String.class))).thenReturn("stringValue");
+        
+        ExtendedTestConfig testConfig = new ExtendedTestConfig();
+
+        FieldSetter<ExtendedTestConfig> fieldSetter = new FieldSetter<ExtendedTestConfig>(configBuilderFactory);
+        fieldSetter.setFields(testConfig, builderConfiguration);
+
+        assertEquals("stringValue", testConfig.testString);
+        assertEquals("stringValue", testConfig.emptyTestString);
+        assertEquals("stringValue", testConfig.extendedTestString);
     }
 }


### PR DESCRIPTION
Enables to use a class hierarchy for config classes.

``` java
class Config {
   @PropertyValue("a")
   private String someString;

   public void getSomeString() {
       return someString;
   }
}

class TestConfig extends Config {
   @PropertyValue("b")
   private String otherString;

   public void getOtherString() {
       return otherString;
   }
}
```

As an example, one can use an extended `testConfig` object created via

``` java
TestConfig testConfig = ConfigBuilder<TestConfig>(TestConfig.class).build();
```

in order to supply extended config information to mock objects injected into an application during test runs.

Fields are fixed to their level in a (now possible) type hierachy. As they cannot be overridden all fields found in the hierarchy are handled separately.

The tests overriding System.out with null were fixed as well.
