### PR TITLE
Better support for Java8 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
         <dependency>
             <groupId>org.reflections</groupId>
             <artifactId>reflections</artifactId>
-            <version>0.9.8</version>
+            <version>0.9.9-RC2</version>
         </dependency>
         <dependency>
             <groupId>commons-cli</groupId>


### PR DESCRIPTION
- when using together with PowerMock an exception occurred, this is because of incompatibilities with the javassist-lib (version from 3.18.2-GA is needed), fixes #23
