### PR TITLE
fixed transformer type recognition and added string to enum transformer

### DIFF
--- a/src/main/java/com/tngtech/configbuilder/annotation/typetransformer/StringToEnumTypeTransformer.java
+++ b/src/main/java/com/tngtech/configbuilder/annotation/typetransformer/StringToEnumTypeTransformer.java
@@ -1,0 +1,15 @@
+package com.tngtech.configbuilder.annotation.typetransformer;
+
+public class StringToEnumTypeTransformer<E extends Enum<E>> extends TypeTransformer<String, E> {
+
+    private final Class<E> enumClass;
+
+    public StringToEnumTypeTransformer(Class<E> enumClass) {
+        this.enumClass = enumClass;
+    }
+
+    @Override
+    public E transform(final String value) {
+        return E.valueOf(enumClass, value.trim().replace(' ', '_').toUpperCase());
+    }
+}

--- a/src/main/java/com/tngtech/configbuilder/annotation/typetransformer/TypeTransformer.java
+++ b/src/main/java/com/tngtech/configbuilder/annotation/typetransformer/TypeTransformer.java
@@ -5,13 +5,15 @@ import com.tngtech.configbuilder.util.GenericsAndCastingHelper;
 import com.tngtech.configbuilder.util.ConfigBuilderFactory;
 import com.tngtech.configbuilder.util.FieldValueTransformer;
 
-import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.util.ArrayList;
+import java.lang.reflect.TypeVariable;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Implementations of this interface transform an object into a different type of object
+ *
  * @param <SourceClass> the type of the parameter before the transformation
  * @param <TargetClass> return type
  */
@@ -33,24 +35,55 @@ public abstract class TypeTransformer<SourceClass, TargetClass> {
     }
 
     public boolean isMatching(Class<?> sourceClass, Class<?> targetClass) {
-        Class<?> transformerSourceClass = getTransformerSourceClass();
-        Class<?> transformerTargetClass = getTransformerTargetClass();
-        if(transformerSourceClass.isAssignableFrom(sourceClass) && targetClass.isAssignableFrom(transformerTargetClass)) {
-            return true;
-        }
-        return false;
+        return getTransformerSourceClass().isAssignableFrom(sourceClass) &&
+                targetClass.isAssignableFrom(getTransformerTargetClass());
     }
 
     protected Class<?> getTransformerSourceClass() {
-        Type typeOfInterface = this.getClass().getGenericSuperclass();
-        Type[] genericTypes = ((ParameterizedType) typeOfInterface).getActualTypeArguments();
+        Type[] genericTypes = determineTypeArguments();
         return genericsAndCastingHelper.castTypeToClass(genericTypes[0]);
     }
 
     protected Class<?> getTransformerTargetClass() {
-        Type typeOfInterface = this.getClass().getGenericSuperclass();
-        Type[] genericTypes = ((ParameterizedType) typeOfInterface).getActualTypeArguments();
+        Type[] genericTypes = determineTypeArguments();
         return genericsAndCastingHelper.castTypeToClass(genericTypes[1]);
+    }
+
+    private Type[] determineTypeArguments() {
+        Class<?> clazz = getClass();
+        Type[] typeArguments = new Type[]{};
+
+        while (!clazz.equals(TypeTransformer.class)) {
+            TypeVariable[] typeParameters = clazz.getTypeParameters();
+
+            Map<TypeVariable, Type> typeVariableMap = buildTypeNameMap(typeArguments, typeParameters);
+
+            typeArguments = ((ParameterizedType) clazz.getGenericSuperclass()).getActualTypeArguments();
+
+            replaceKnownTypes(typeArguments, typeVariableMap);
+
+            clazz = clazz.getSuperclass();
+        }
+        return typeArguments;
+    }
+
+    private Map<TypeVariable, Type> buildTypeNameMap(Type[] typeArguments, TypeVariable[] typeParameters) {
+        Map<TypeVariable, Type> typeVariableMap = new HashMap<TypeVariable, Type>();
+        for (int i = 0; i < typeParameters.length; i++) {
+            typeVariableMap.put(typeParameters[i], typeArguments[i]);
+        }
+        return typeVariableMap;
+    }
+
+    private void replaceKnownTypes(Type[] typeArguments, Map<TypeVariable, Type> typeVariableMap) {
+        for (int i = 0; i < typeArguments.length; i++) {
+            if (typeArguments[i] instanceof TypeVariable) {
+                TypeVariable typeVariable = (TypeVariable) typeArguments[i];
+                if (typeVariableMap.containsKey(typeVariable)) {
+                    typeArguments[i] = typeVariableMap.get(typeVariable);
+                }
+            }
+        }
     }
 
     public void setTargetType(Type targetType) {

--- a/src/test/java/com/tngtech/configbuilder/annotation/typetransformer/StringToEnumTypeTransformerTest.java
+++ b/src/test/java/com/tngtech/configbuilder/annotation/typetransformer/StringToEnumTypeTransformerTest.java
@@ -1,0 +1,58 @@
+package com.tngtech.configbuilder.annotation.typetransformer;
+
+import com.tngtech.configbuilder.configuration.ErrorMessageSetup;
+import com.tngtech.configbuilder.util.ConfigBuilderFactory;
+import com.tngtech.configbuilder.util.FieldValueTransformer;
+import com.tngtech.configbuilder.util.GenericsAndCastingHelper;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StringToEnumTypeTransformerTest {
+
+    private StringToTestEnumTransformer transformer;
+
+    enum TestEnum {
+        ONE
+    }
+
+    public static class StringToTestEnumTransformer extends StringToEnumTypeTransformer<TestEnum> {
+        public StringToTestEnumTransformer() {
+            super(TestEnum.class);
+        }
+    }
+
+    @Mock
+    private ConfigBuilderFactory configBuilderFactory;
+
+    @Before
+    public void setUp() {
+        initializeFactoryMocks();
+        transformer = new StringToTestEnumTransformer();
+        transformer.initialize(new FieldValueTransformer(configBuilderFactory), configBuilderFactory);
+    }
+
+    private void initializeFactoryMocks() {
+        when(configBuilderFactory.getInstance(ErrorMessageSetup.class)).thenReturn(new ErrorMessageSetup());
+        when(configBuilderFactory.getInstance(GenericsAndCastingHelper.class)).thenReturn(new GenericsAndCastingHelper());
+    }
+
+    @Test
+    public void testTransform() throws Exception {
+        assertThat(transformer.transform(TestEnum.ONE.name()), is(TestEnum.ONE));
+    }
+
+    @Test
+    public void testIsMatching() throws Exception {
+        assertTrue(transformer.isMatching(String.class, TestEnum.class));
+        assertFalse(transformer.isMatching(String.class, Integer.class));
+        assertTrue(transformer.isMatching(String.class, Enum.class));
+    }
+}

--- a/src/test/java/com/tngtech/configbuilder/annotation/typetransformer/TypeTransformerTest.java
+++ b/src/test/java/com/tngtech/configbuilder/annotation/typetransformer/TypeTransformerTest.java
@@ -1,0 +1,121 @@
+package com.tngtech.configbuilder.annotation.typetransformer;
+
+import com.tngtech.configbuilder.util.ConfigBuilderFactory;
+import com.tngtech.configbuilder.util.FieldValueTransformer;
+import com.tngtech.configbuilder.util.GenericsAndCastingHelper;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TypeTransformerTest {
+
+    private static class TestTypeTransformer extends TypeTransformer<String, Integer> {
+        @Override
+        public Integer transform(String argument) {
+            return Integer.getInteger(argument);
+        }
+    }
+
+    private static class TestIntermediateTypeTransformer<T> extends TypeTransformer<String, T> {
+        @Override
+        public T transform(String argument) {
+            return null;
+        }
+    }
+
+    private static class TestInheritedTypeTransformer extends TestIntermediateTypeTransformer<Integer> {
+    }
+
+    private static class TestUntypedIntermediateTypeTransformer<U, V> extends TypeTransformer<U, V> {
+        @Override
+        public V transform(U argument) {
+            return null;
+        }
+    }
+
+    private static class TestUntypedInheritedTypeTransformer extends TestUntypedIntermediateTypeTransformer<String, Integer> {
+    }
+
+    private static class TestUntypedRevertedIntermediateTypeTransformer<V, U> extends TypeTransformer<U, V> {
+        @Override
+        public V transform(U argument) {
+            return null;
+        }
+    }
+
+    private static class TestUntypedRevertedInheritedTypeTransformer extends TestUntypedRevertedIntermediateTypeTransformer<Integer, String> {
+    }
+
+    @Mock
+    private FieldValueTransformer fieldValueTransformer;
+
+    @Mock
+    private ConfigBuilderFactory configBuilderFactory;
+
+    @Before
+    public void setUp() {
+        when(configBuilderFactory.getInstance(GenericsAndCastingHelper.class)).thenReturn(new GenericsAndCastingHelper());
+    }
+
+    private TypeTransformer createSimpleTypeTransformer() {
+        TypeTransformer typeTransformer = new TestTypeTransformer();
+        typeTransformer.initialize(fieldValueTransformer, configBuilderFactory);
+        return typeTransformer;
+    }
+
+    private TypeTransformer createInheritedTypeTransformer() {
+        TypeTransformer typeTransformer = new TestInheritedTypeTransformer();
+        typeTransformer.initialize(fieldValueTransformer, configBuilderFactory);
+        return typeTransformer;
+    }
+
+    private TypeTransformer createUntypedInheritedTypeTransformer() {
+        TypeTransformer typeTransformer = new TestUntypedInheritedTypeTransformer();
+        typeTransformer.initialize(fieldValueTransformer, configBuilderFactory);
+        return typeTransformer;
+    }
+
+    private TypeTransformer createUntypedRevertedInheritedTypeTransformer() {
+        TypeTransformer typeTransformer = new TestUntypedRevertedInheritedTypeTransformer();
+        typeTransformer.initialize(fieldValueTransformer, configBuilderFactory);
+        return typeTransformer;
+    }
+
+    @Test
+    public void testSimpleTypeTransformer() {
+        final TypeTransformer typeTransformer = createSimpleTypeTransformer();
+
+        //noinspection unchecked
+        assertTrue(typeTransformer.isMatching(String.class, Integer.class));
+    }
+
+    @Test
+    public void testInheritedTypeTransformerMatch() {
+        final TypeTransformer typeTransformer = createInheritedTypeTransformer();
+
+        //noinspection unchecked
+        assertTrue(typeTransformer.isMatching(String.class, Integer.class));
+    }
+
+    @Test
+    public void testUntypedInheritedTypeTransformerMatch() {
+        final TypeTransformer typeTransformer = createUntypedInheritedTypeTransformer();
+
+        //noinspection unchecked
+        assertTrue(typeTransformer.isMatching(String.class, Integer.class));
+    }
+
+    @Test
+    public void testUntypedRevertedInheritedTypeTransformerMatch() {
+        final TypeTransformer typeTransformer = createUntypedRevertedInheritedTypeTransformer();
+
+        //noinspection unchecked
+        assertTrue(typeTransformer.isMatching(String.class, Integer.class));
+    }
+}


### PR DESCRIPTION
The TypeTransformer implementation did not allow for distribution of the type parameters in different inheritance levels.

This PR fixes this behaviour and adds a StringToEnumTypeTransformer which can be extended for simple Enum transformations.