### PR TITLE
new annotation @PropertyNamePrefix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>2.4.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.unitils</groupId>
             <artifactId>unitils-core</artifactId>
             <version>3.4.2</version>

--- a/src/main/java/com/tngtech/configbuilder/ConfigBuilder.java
+++ b/src/main/java/com/tngtech/configbuilder/ConfigBuilder.java
@@ -1,6 +1,7 @@
 package com.tngtech.configbuilder;
 
 import com.tngtech.configbuilder.annotation.configuration.LoadingOrder;
+import com.tngtech.configbuilder.annotation.configuration.PropertyNamePrefix;
 import com.tngtech.configbuilder.annotation.propertyloaderconfiguration.ErrorMessageFile;
 import com.tngtech.configbuilder.configuration.BuilderConfiguration;
 import com.tngtech.configbuilder.configuration.ErrorMessageSetup;
@@ -270,6 +271,10 @@ public class ConfigBuilder<T> {
     private void setupBuilderConfiguration(PropertyLoader propertyLoader) {
         if (configClass.isAnnotationPresent(LoadingOrder.class)) {
             builderConfiguration.setAnnotationOrder(configClass.getAnnotation(LoadingOrder.class).value());
+        }
+
+        if (configClass.isAnnotationPresent(PropertyNamePrefix.class)) {
+            builderConfiguration.setPropertyNamePrefixes(configClass.getAnnotation(PropertyNamePrefix.class).value());
         }
         
         final Properties properties = propertyLoader.load();

--- a/src/main/java/com/tngtech/configbuilder/annotation/configuration/PropertyNamePrefix.java
+++ b/src/main/java/com/tngtech/configbuilder/annotation/configuration/PropertyNamePrefix.java
@@ -1,0 +1,18 @@
+package com.tngtech.configbuilder.annotation.configuration;
+
+import com.tngtech.configbuilder.annotation.valueextractor.CommandLineValue;
+import com.tngtech.configbuilder.annotation.valueextractor.DefaultValue;
+import com.tngtech.configbuilder.annotation.valueextractor.PropertyValue;
+
+import java.lang.annotation.*;
+
+/**
+ * This annotation is used to specify additional prefixes to be included in the search for property names
+ * <b>Usage:</b> <code>@PropertyNamePrefix(value = {"test.prefix."})</code>
+ */
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PropertyNamePrefix {
+    public String[] value() default {""};
+
+}

--- a/src/main/java/com/tngtech/configbuilder/annotation/valueextractor/ImportedValueProcessor.java
+++ b/src/main/java/com/tngtech/configbuilder/annotation/valueextractor/ImportedValueProcessor.java
@@ -15,10 +15,10 @@ public class ImportedValueProcessor implements ValueExtractorProcessor {
         BuilderConfiguration builderConfiguration = configBuilderFactory.getInstance(BuilderConfiguration.class);
         Object importedConfiguration = builderConfiguration.getImportedConfiguration();
 
-        if(importedConfiguration == null) {
+        if (importedConfiguration == null) {
             return null;
         }
-        
+
         String fieldName = ((ImportedValue) annotation).value();
         Object result;
 

--- a/src/main/java/com/tngtech/configbuilder/annotation/valueextractor/PropertyValueProcessor.java
+++ b/src/main/java/com/tngtech/configbuilder/annotation/valueextractor/PropertyValueProcessor.java
@@ -4,6 +4,7 @@ import com.tngtech.configbuilder.configuration.BuilderConfiguration;
 import com.tngtech.configbuilder.util.ConfigBuilderFactory;
 
 import java.lang.annotation.Annotation;
+import java.util.Properties;
 
 /**
  * Processes PropertyValue annotations, implements ValueExtractorProcessor
@@ -12,7 +13,16 @@ public class PropertyValueProcessor implements ValueExtractorProcessor {
 
     public String getValue(Annotation annotation, ConfigBuilderFactory configBuilderFactory) {
         BuilderConfiguration builderConfiguration = configBuilderFactory.getInstance(BuilderConfiguration.class);
-        
-        return builderConfiguration.getProperties().getProperty(((PropertyValue) annotation).value());
+
+        final Properties properties = builderConfiguration.getProperties();
+        final String propertyName = ((PropertyValue) annotation).value();
+
+        for (final String propertyNamePrefix : builderConfiguration.getPropertyNamePrefixes()) {
+            final String fullPropertyName = propertyNamePrefix + propertyName;
+            if (properties.containsKey(fullPropertyName)) {
+                return properties.getProperty(fullPropertyName);
+            }
+        }
+        return null;
     }
 }

--- a/src/main/java/com/tngtech/configbuilder/configuration/BuilderConfiguration.java
+++ b/src/main/java/com/tngtech/configbuilder/configuration/BuilderConfiguration.java
@@ -15,6 +15,7 @@ public class BuilderConfiguration {
     private CommandLine commandLine;
     private Object importedConfiguration;
     private Class<? extends Annotation>[] annotationOrder = new Class[]{CommandLineValue.class, PropertyValue.class, EnvironmentVariableValue.class, SystemPropertyValue.class, ImportedValue.class, DefaultValue.class};
+    private String[] propertyNamePrefixes = new String[]{""};
 
     public BuilderConfiguration() {
         properties = new Properties();
@@ -52,5 +53,13 @@ public class BuilderConfiguration {
 
     public Class<? extends Annotation>[] getAnnotationOrder() {
         return annotationOrder;
+    }
+
+    public void setPropertyNamePrefixes(String[] propertyNamePrefixes) {
+        this.propertyNamePrefixes = propertyNamePrefixes;
+    }
+
+    public String[] getPropertyNamePrefixes() {
+        return propertyNamePrefixes;
     }
 }

--- a/src/test/java/com/tngtech/configbuilder/ConfigBuilderFeatureIntegrationTest.java
+++ b/src/test/java/com/tngtech/configbuilder/ConfigBuilderFeatureIntegrationTest.java
@@ -1,0 +1,24 @@
+package com.tngtech.configbuilder;
+
+import com.tngtech.configbuilder.testclasses.TestConfigPropertyNamePrefix;
+import com.tngtech.configbuilder.testclasses.TestConfigWithoutDefaultConstructor;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ConfigBuilderFeatureIntegrationTest {
+    @Test
+    public void testConfigBuilderWithConstructorArgument() {
+        TestConfigWithoutDefaultConstructor c = ConfigBuilder.on(TestConfigWithoutDefaultConstructor.class).build(3);
+
+        assertThat(c.getNumber()).isEqualTo(3);
+    }
+
+
+    @Test
+    public void testConfigBuilderWithPropertyNamePrefix() {
+        TestConfigPropertyNamePrefix config = ConfigBuilder.on(TestConfigPropertyNamePrefix.class).build();
+
+        assertThat(config.getFoo()).isEqualTo("first property");
+    }
+}

--- a/src/test/java/com/tngtech/configbuilder/ConfigBuilderIntegrationTest.java
+++ b/src/test/java/com/tngtech/configbuilder/ConfigBuilderIntegrationTest.java
@@ -5,7 +5,6 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.tngtech.configbuilder.testclasses.TestConfig;
-import com.tngtech.configbuilder.testclasses.TestConfigWithoutDefaultConstructor;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -21,7 +20,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.unitils.reflectionassert.ReflectionAssert.assertReflectionEquals;
 import static org.unitils.reflectionassert.ReflectionAssert.assertLenientEquals;
@@ -52,8 +50,8 @@ public class ConfigBuilderIntegrationTest {
         testConfig.setSomeString("Hello, World!");
         testConfig.setSomeNumber(3);
         testConfig.setBoolean(true);
-        testConfig.setStringCollection(Lists.newArrayList("first entry","second entry"));
-        testConfig.setIntegerList(Lists.newArrayList(1,2,3,4,5));
+        testConfig.setStringCollection(Lists.newArrayList("first entry", "second entry"));
+        testConfig.setIntegerList(Lists.newArrayList(1, 2, 3, 4, 5));
         testConfig.setPathCollection(Sets.newHashSet(Paths.get("/etc"), Paths.get("/usr")));
         testConfig.setHomeDir(Paths.get(System.getenv("HOME")));
         testConfig.setSystemProperty(System.getProperty("user.language"));
@@ -73,13 +71,6 @@ public class ConfigBuilderIntegrationTest {
         Object result = configBuilder.withCommandLineArgs(args).build();
         assertReflectionEquals(configInstance, result);
         assertTrue(outContent.toString().contains("config validated"));
-    }
-
-    @Test
-    public void testConfigBuilderWithConstructorArgument() {
-        ConfigBuilder<TestConfigWithoutDefaultConstructor> configBuilder = new ConfigBuilder<TestConfigWithoutDefaultConstructor>(TestConfigWithoutDefaultConstructor.class);
-        TestConfigWithoutDefaultConstructor c = configBuilder.build(3);
-        assertEquals(3, c.getNumber());
     }
 
     @Test

--- a/src/test/java/com/tngtech/configbuilder/annotation/valueextractor/PropertyValueProcessorTest.java
+++ b/src/test/java/com/tngtech/configbuilder/annotation/valueextractor/PropertyValueProcessorTest.java
@@ -5,13 +5,15 @@ import com.tngtech.configbuilder.util.ConfigBuilderFactory;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.Properties;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PropertyValueProcessorTest {
@@ -29,15 +31,58 @@ public class PropertyValueProcessorTest {
 
     @Before
     public void setUp() throws Exception {
+        when(configBuilderFactory.getInstance(BuilderConfiguration.class)).thenReturn(builderConfiguration);
+        when(builderConfiguration.getProperties()).thenReturn(properties);
+
         propertyValueProcessor = new PropertyValueProcessor();
     }
 
     @Test
     public void testPropertyValueProcessor() {
-        when(configBuilderFactory.getInstance(BuilderConfiguration.class)).thenReturn(builderConfiguration);
-        when(builderConfiguration.getProperties()).thenReturn(properties);
+        when(builderConfiguration.getPropertyNamePrefixes()).thenReturn(new String[]{""});
         when(propertyValue.value()).thenReturn("test");
+        when(properties.containsKey("test")).thenReturn(true);
         when(properties.getProperty("test")).thenReturn("passed");
-        assertEquals("passed", propertyValueProcessor.getValue(propertyValue, configBuilderFactory));
+
+        assertThat(propertyValueProcessor.getValue(propertyValue, configBuilderFactory)).isEqualTo("passed");
+    }
+
+    @Test
+    public void testPropertyValueProcessorWithPropertyNamePrefix() {
+        when(builderConfiguration.getPropertyNamePrefixes()).thenReturn(new String[]{"prefix."});
+        when(propertyValue.value()).thenReturn("test");
+        when(properties.containsKey("prefix.test")).thenReturn(true);
+        when(properties.getProperty("prefix.test")).thenReturn("passed");
+
+        assertThat(propertyValueProcessor.getValue(propertyValue, configBuilderFactory)).isEqualTo("passed");
+    }
+
+    @Test
+    public void testPropertyValueProcessorWithPropertyNamePrefixes() {
+        when(builderConfiguration.getPropertyNamePrefixes()).thenReturn(new String[]{"other.", "prefix."});
+        when(propertyValue.value()).thenReturn("test");
+        when(properties.containsKey("prefix.test")).thenReturn(true);
+        when(properties.getProperty("prefix.test")).thenReturn("passed");
+
+        assertThat(propertyValueProcessor.getValue(propertyValue, configBuilderFactory)).isEqualTo("passed");
+
+        final InOrder inOrder = inOrder(properties);
+        inOrder.verify(properties).containsKey("other.test");
+        inOrder.verify(properties).containsKey("prefix.test");
+        inOrder.verify(properties).getProperty("prefix.test");
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void testPropertyValueProcessorPropertyNotFound() {
+        when(builderConfiguration.getPropertyNamePrefixes()).thenReturn(new String[]{""});
+        when(propertyValue.value()).thenReturn("test");
+        when(properties.contains("test")).thenReturn(false);
+
+        assertThat(propertyValueProcessor.getValue(propertyValue, configBuilderFactory)).isNull();
+
+        verify(properties).containsKey("test");
+        verify(properties, never()).getProperty(anyString());
+        verifyNoMoreInteractions(properties);
     }
 }

--- a/src/test/java/com/tngtech/configbuilder/testclasses/TestConfigPropertyNamePrefix.java
+++ b/src/test/java/com/tngtech/configbuilder/testclasses/TestConfigPropertyNamePrefix.java
@@ -1,0 +1,17 @@
+package com.tngtech.configbuilder.testclasses;
+
+import com.tngtech.configbuilder.annotation.configuration.PropertyNamePrefix;
+import com.tngtech.configbuilder.annotation.propertyloaderconfiguration.PropertiesFiles;
+import com.tngtech.configbuilder.annotation.valueextractor.PropertyValue;
+
+@PropertiesFiles("testPropertyNamePrefix")
+@PropertyNamePrefix("test.prefix.")
+public class TestConfigPropertyNamePrefix {
+
+    @PropertyValue("foo")
+    private String foo;
+
+    public String getFoo() {
+        return foo;
+    }
+}

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,0 +1,4 @@
+log4j.rootLogger=DEBUG, A
+log4j.appender.A=org.apache.log4j.ConsoleAppender
+log4j.appender.A.layout=org.apache.log4j.PatternLayout
+log4j.appender.A.layout.ConversionPattern=%C - %m%n

--- a/src/test/resources/testPropertyNamePrefix.properties
+++ b/src/test/resources/testPropertyNamePrefix.properties
@@ -1,0 +1,2 @@
+test.prefix.foo=first property
+test.prefix.bar=second property


### PR DESCRIPTION
This annotation helps to extract a common property name prefix:

```
@PropertyNamePrefix("test.prefix.")
public class TestConfigPropertyNamePrefix {

    @PropertyValue("foo")
    private String foo;
```

The value of the field `foo` will be filled with the property named 'test.prefix.foo'.

More than one prefix can be specified:

```
@PropertyNamePrefix({"foo.", "bar."})
```
The first property found by name will be used to get the corresponding value.