### PR TITLE
Update bean validation to 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Its features include
 2. configuring of not only String values, but fields of arbitrary types  
 3. configuring of collection fields  
 4. merging configs  
-5. JSR303 validation of the instances it builds.  
+5. [JSR380](https://www.jcp.org/en/jsr/detail?id=380) validation of the instances it builds.
 
 Motivation
 ----------

--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
         <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
-            <version>1.1.0.Final</version>
+            <version>2.0.1.Final</version>
         </dependency>
         <dependency>
             <groupId>javax.el</groupId>
@@ -203,9 +203,9 @@
             <version>2.2.6</version>
         </dependency>
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>5.3.4.Final</version>
+            <version>6.0.10.Final</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
This is a mayor change and would include support for [JSR380](https://www.jcp.org/en/jsr/detail?id=380).