### PR TITLE
include OWASP dependency check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,18 @@
                     </execution>
                 </executions>
             </plugin>
+              <plugin>
+              <groupId>org.owasp</groupId>
+              <artifactId>dependency-check-maven</artifactId>
+              <version>3.2.1</version>
+              <executions>
+                  <execution>
+                      <goals>
+                          <goal>check</goal>
+                      </goals>
+                  </execution>
+              </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
@@ -193,14 +205,9 @@
             <version>2.0.1.Final</version>
         </dependency>
         <dependency>
-            <groupId>javax.el</groupId>
-            <artifactId>javax.el-api</artifactId>
-            <version>3.0.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.web</groupId>
+            <groupId>org.glassfish</groupId>
             <artifactId>javax.el</artifactId>
-            <version>2.2.6</version>
+            <version>3.0.1-b10</version>
         </dependency>
         <dependency>
             <groupId>org.hibernate.validator</groupId>


### PR DESCRIPTION
and remove javax.el-api, use recent version of javax.el to eliminate OWASP warnings