### PR TITLE
more flexible command line value description

### DIFF
--- a/src/main/java/com/tngtech/configbuilder/ConfigBuilder.java
+++ b/src/main/java/com/tngtech/configbuilder/ConfigBuilder.java
@@ -12,7 +12,6 @@ import com.tngtech.propertyloader.impl.DefaultPropertyLocationContainer;
 import com.tngtech.propertyloader.impl.DefaultPropertySuffixContainer;
 import com.tngtech.propertyloader.impl.interfaces.PropertyLoaderFilter;
 import org.apache.commons.cli.HelpFormatter;
-import org.apache.commons.cli.Options;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,7 +60,6 @@ public class ConfigBuilder<T> {
     private final ConstructionHelper<T> constructionHelper;
 
     private Class<T> configClass;
-    private Options commandLineOptions;
     private PropertyLoader propertyLoader;
     private Properties additionalProperties;
     private String[] commandLineArgs = {};
@@ -77,8 +75,7 @@ public class ConfigBuilder<T> {
         this.constructionHelper = configBuilderFactory.getInstance(ConstructionHelper.class);
         this.additionalProperties = configBuilderFactory.createInstance(Properties.class);
 
-        propertyLoader = configBuilderFactory.getInstance(PropertyLoaderConfigurator.class).configurePropertyLoader(configClass);
-        commandLineOptions = commandLineHelper.getOptions(configClass);
+        this.propertyLoader = configBuilderFactory.getInstance(PropertyLoaderConfigurator.class).configurePropertyLoader(configClass);
     }
 
     /**
@@ -241,9 +238,10 @@ public class ConfigBuilder<T> {
      * Prints a help message for all command line options that are configured in the config class.
      */
     public void printCommandLineHelp() {
+        initializeErrorMessageSetup(propertyLoader);
         HelpFormatter formatter = new HelpFormatter();
         formatter.setSyntaxPrefix("Command Line Options for class " + configClass.getSimpleName() + ":");
-        formatter.printHelp(" ", commandLineOptions);
+        formatter.printHelp(" ", commandLineHelper.getOptions(configClass));
     }
 
     /**

--- a/src/main/java/com/tngtech/configbuilder/annotation/valueextractor/CommandLineValueDescriptor.java
+++ b/src/main/java/com/tngtech/configbuilder/annotation/valueextractor/CommandLineValueDescriptor.java
@@ -6,10 +6,10 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * This annotation is used to mark a method as description text supplier for command line options.<br>
- * The annotated method must be static and accept a single parameter, which is the longOpt name of a command line option.<br>
- * There may be at most one such method per class (or none at all).<br>
- * If a field is annotated with {@link com.tngtech.configbuilder.annotation.valueextractor.CommandLineValue} but has no description,<br>
+ * This annotation is used to mark a method as description text supplier for command line options.
+ * The annotated method must be static and accept a single String parameter, which is the longOpt name of a command line option.
+ * There may be at most one such method per class.<br>
+ * If a field is annotated with {@link com.tngtech.configbuilder.annotation.valueextractor.CommandLineValue} but has no description,
  * then this method is called to generate the description text.<br>
  * <b>Usage:</b> <code>@CommandLineValueDescriptor</code>
  */

--- a/src/main/java/com/tngtech/configbuilder/annotation/valueextractor/CommandLineValueDescriptor.java
+++ b/src/main/java/com/tngtech/configbuilder/annotation/valueextractor/CommandLineValueDescriptor.java
@@ -1,0 +1,18 @@
+package com.tngtech.configbuilder.annotation.valueextractor;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation is used to mark a method as description text supplier for command line options.<br>
+ * The annotated method must be static and accept a single parameter, which is the longOpt name of a command line option.<br>
+ * There may be at most one such method per class (or none at all).<br>
+ * If a field is annotated with {@link com.tngtech.configbuilder.annotation.valueextractor.CommandLineValue} but has no description,<br>
+ * then this method is called to generate the description text.<br>
+ * <b>Usage:</b> <code>@CommandLineValueDescriptor</code>
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CommandLineValueDescriptor {}

--- a/src/main/java/com/tngtech/configbuilder/exception/InvalidDescriptionMethodException.java
+++ b/src/main/java/com/tngtech/configbuilder/exception/InvalidDescriptionMethodException.java
@@ -1,0 +1,3 @@
+package com.tngtech.configbuilder.exception;
+
+public class InvalidDescriptionMethodException extends RuntimeException {}

--- a/src/main/resources/errors.properties
+++ b/src/main/resources/errors.properties
@@ -11,4 +11,5 @@ com.tngtech.configbuilder.exception.TypeTransformerException = couldn't find a t
 com.tngtech.configbuilder.exception.PrimitiveParsingException = unable to parse "%s" to %s
 com.tngtech.configbuilder.exception.ImportedConfigurationException = couldn't find a field with the name %s
 com.tngtech.configbuilder.exception.FactoryInstantiationException = could not create an instance of %s
+com.tngtech.configbuilder.exception.InvalidDescriptionMethodException = invalid or multiple use of the @CommandLineValueDescriptor annotation (the annotated method must be static and accept a single String parameter)
 standardMessage = %s was thrown

--- a/src/main/resources/errors_de.properties
+++ b/src/main/resources/errors_de.properties
@@ -11,4 +11,5 @@ com.tngtech.configbuilder.exception.TypeTransformerException = Konnte keinen Tra
 com.tngtech.configbuilder.exception.PrimitiveParsingException = Kann "%s" nicht zu %s verarbeiten!
 com.tngtech.configbuilder.exception.ImportedConfigurationException = Konnte kein Feld mit dem Namen %s finden.
 com.tngtech.configbuilder.exception.FactoryInstantiationException = Konnte keine Instanz von %s erzeugen.
+com.tngtech.configbuilder.exception.InvalidDescriptionMethodException = ungültige oder mehrfache Verwendung der @CommandLineValueDescriptor-Annotation (die annotierte Methode muss statisch sein und einen einzelnen String-Parameter haben)
 standardMessage = Es gab eine Exception vom Typ %s

--- a/src/main/resources/errors_en.properties
+++ b/src/main/resources/errors_en.properties
@@ -11,4 +11,5 @@ com.tngtech.configbuilder.exception.TypeTransformerException = couldn't find a t
 com.tngtech.configbuilder.exception.PrimitiveParsingException = unable to parse "%s" to %s
 com.tngtech.configbuilder.exception.ImportedConfigurationException = couldn't find a field with the name %s
 com.tngtech.configbuilder.exception.FactoryInstantiationException = could not create an instance of %s
+com.tngtech.configbuilder.exception.InvalidDescriptionMethodException = invalid or multiple use of the @CommandLineValueDescriptor annotation (the annotated method must be static and accept a single String parameter)
 standardMessage = %s was thrown

--- a/src/test/java/com/tngtech/configbuilder/util/CommandLineHelperExceptionHandlingTest.java
+++ b/src/test/java/com/tngtech/configbuilder/util/CommandLineHelperExceptionHandlingTest.java
@@ -1,0 +1,73 @@
+package com.tngtech.configbuilder.util;
+
+import com.tngtech.configbuilder.ConfigBuilder;
+import com.tngtech.configbuilder.annotation.valueextractor.CommandLineValue;
+import com.tngtech.configbuilder.annotation.valueextractor.CommandLineValueDescriptor;
+import com.tngtech.configbuilder.exception.ConfigBuilderException;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class CommandLineHelperExceptionHandlingTest {
+
+    private static class TestConfig {
+
+        @CommandLineValue(shortOpt = "u", longOpt = "user", required = true)
+        public String user;
+    }
+
+    private static class TestConfigWithInvalidCommandLineValueDescriptor {
+
+        @CommandLineValue(shortOpt = "u", longOpt = "user")
+        public String user;
+
+        @CommandLineValueDescriptor
+        private static void description() { }
+    }
+
+    private static class TestConfigWithMultipleCommandLineValueDescriptors {
+
+        @CommandLineValue(shortOpt = "u", longOpt = "user")
+        public String user;
+
+        @CommandLineValueDescriptor
+        private static String description1() {
+            return "";
+        }
+
+        @CommandLineValueDescriptor
+        private static String description2() {
+            return "";
+        }
+    }
+
+    @Test
+    public void testUndefinedCommandLineOption() {
+        String[]  args = new String[]{"nd", "notDefined"};
+        assertThatThrownBy(() -> ConfigBuilder.on(TestConfig.class).withCommandLineArgs(args).build())
+                .isInstanceOf(ConfigBuilderException.class)
+                .hasMessageContaining("unable to parse command line arguments");
+    }
+
+    @Test
+    public void testInvalidCommandLineValueDescriptor() {
+        assertThatThrownBy(() -> ConfigBuilder.on(TestConfigWithInvalidCommandLineValueDescriptor.class).printCommandLineHelp())
+                .isInstanceOf(ConfigBuilderException.class)
+                .hasMessageContaining("invalid or multiple use of the @CommandLineValueDescriptor annotation");
+
+        assertThatThrownBy(() -> ConfigBuilder.on(TestConfigWithInvalidCommandLineValueDescriptor.class).build())
+                .isInstanceOf(ConfigBuilderException.class)
+                .hasMessageContaining("invalid or multiple use of the @CommandLineValueDescriptor annotation");
+    }
+
+    @Test
+    public void testMultipleCommandLineValueDescriptors() {
+        assertThatThrownBy(() -> ConfigBuilder.on(TestConfigWithMultipleCommandLineValueDescriptors.class).printCommandLineHelp())
+                .isInstanceOf(ConfigBuilderException.class)
+                .hasMessageContaining("invalid or multiple use of the @CommandLineValueDescriptor annotation");
+
+        assertThatThrownBy(() -> ConfigBuilder.on(TestConfigWithMultipleCommandLineValueDescriptors.class).build())
+                .isInstanceOf(ConfigBuilderException.class)
+                .hasMessageContaining("invalid or multiple use of the @CommandLineValueDescriptor annotation");
+    }
+}

--- a/src/test/java/com/tngtech/configbuilder/util/CommandLineHelperTest.java
+++ b/src/test/java/com/tngtech/configbuilder/util/CommandLineHelperTest.java
@@ -27,16 +27,16 @@ public class CommandLineHelperTest {
 
     private static class TestConfig {
 
-        @CommandLineValue(shortOpt = "u", longOpt = "user", required = true)
+        @CommandLineValue(shortOpt = "u", longOpt = "user", required = true, description = "some static description string")
         public String aString;
         @CommandLineValue(shortOpt = "v", longOpt = "vir", required = false)
         public String anotherString;
 
         @CommandLineValueDescriptor
-        private static String commandLineValueDescription(String longOpt) {
+        private static String description(String longOpt) {
             switch (longOpt) {
                 case "vir":
-                    return "some description string";
+                    return "some dynamically generated description";
                 default:
                     return "";
             }
@@ -104,7 +104,8 @@ public class CommandLineHelperTest {
         when(configBuilderFactory.createInstance(Options.class)).thenReturn(options1);
         assertThat(commandLineHelper.getOptions(TestConfig.class)).isEqualTo(options1);
         assertThat(options1.getOption("user").getLongOpt()).isEqualTo("user");
+        assertThat(options1.getOption("user").getDescription()).isEqualTo("some static description string");
         assertThat(options1.getOption("vir").getOpt()).isEqualTo("v");
-        assertThat(options1.getOption("vir").getDescription()).isEqualTo("some description string");
+        assertThat(options1.getOption("vir").getDescription()).isEqualTo("some dynamically generated description");
     }
 }

--- a/src/test/java/com/tngtech/configbuilder/util/CommandLineHelperTest.java
+++ b/src/test/java/com/tngtech/configbuilder/util/CommandLineHelperTest.java
@@ -1,11 +1,13 @@
 package com.tngtech.configbuilder.util;
 
-import com.google.common.collect.FluentIterable;
-import com.google.common.collect.ImmutableList;
 import com.tngtech.configbuilder.annotation.valueextractor.CommandLineValue;
+import com.tngtech.configbuilder.annotation.valueextractor.CommandLineValueDescriptor;
 import com.tngtech.configbuilder.configuration.ErrorMessageSetup;
 import com.tngtech.configbuilder.exception.ConfigBuilderException;
-import org.apache.commons.cli.*;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -13,12 +15,10 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import java.lang.reflect.Field;
-import java.util.Comparator;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
-import static com.google.common.collect.Sets.newHashSet;
+import static java.util.Comparator.comparing;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
@@ -26,10 +26,21 @@ import static org.mockito.Mockito.*;
 public class CommandLineHelperTest {
 
     private static class TestConfig {
+
         @CommandLineValue(shortOpt = "u", longOpt = "user", required = true)
         public String aString;
         @CommandLineValue(shortOpt = "v", longOpt = "vir", required = false)
         public String anotherString;
+
+        @CommandLineValueDescriptor
+        private static String commandLineValueDescription(String longOpt) {
+            switch (longOpt) {
+                case "vir":
+                    return "some description string";
+                default:
+                    return "";
+            }
+        }
     }
 
     private CommandLineHelper commandLineHelper;
@@ -44,19 +55,15 @@ public class CommandLineHelperTest {
     @Mock
     private ConfigBuilderFactory configBuilderFactory;
     @Mock
-    private AnnotationHelper annotationHelper;
-    @Mock
     private ErrorMessageSetup errorMessageSetup;
 
     @Before
     public void setUp() throws Exception {
-        when(configBuilderFactory.getInstance(AnnotationHelper.class)).thenReturn(annotationHelper);
+        when(configBuilderFactory.getInstance(AnnotationHelper.class)).thenReturn(new AnnotationHelper());
         when(configBuilderFactory.getInstance(ErrorMessageSetup.class)).thenReturn(errorMessageSetup);
 
         commandLineHelper = new CommandLineHelper(configBuilderFactory);
 
-        Set<Field> fields = newHashSet(TestConfig.class.getDeclaredFields());
-        when(annotationHelper.getFieldsAnnotatedWith(TestConfig.class, CommandLineValue.class)).thenReturn(fields);
         when(parser.parse(options, args)).thenReturn(commandLine);
     }
 
@@ -68,11 +75,11 @@ public class CommandLineHelperTest {
         assertThat(commandLineHelper.getCommandLine(TestConfig.class, args)).isSameAs(commandLine);
         verify(options, times(2)).addOption(captor.capture());
         verify(parser).parse(options, args);
-        List<Option> options = captor.getAllValues();
 
-        assertThat(options).hasSize(2);
+        List<Option> sortedOptions = new ArrayList<>(captor.getAllValues());
+        sortedOptions.sort(comparing(Option::getLongOpt));
 
-        final ImmutableList<Option> sortedOptions = FluentIterable.from(options).toSortedList((o1, o2) -> o1.getLongOpt().compareTo(o2.getLongOpt()));
+        assertThat(sortedOptions).hasSize(2);
 
         assertThat(sortedOptions.get(0).getLongOpt()).isEqualTo("user");
         assertThat(sortedOptions.get(0).getOpt()).isEqualTo("u");
@@ -98,5 +105,6 @@ public class CommandLineHelperTest {
         assertThat(commandLineHelper.getOptions(TestConfig.class)).isEqualTo(options1);
         assertThat(options1.getOption("user").getLongOpt()).isEqualTo("user");
         assertThat(options1.getOption("vir").getOpt()).isEqualTo("v");
+        assertThat(options1.getOption("vir").getDescription()).isEqualTo("some description string");
     }
 }

--- a/src/test/java/com/tngtech/configbuilder/util/CommandLineHelperTest.java
+++ b/src/test/java/com/tngtech/configbuilder/util/CommandLineHelperTest.java
@@ -3,7 +3,6 @@ package com.tngtech.configbuilder.util;
 import com.tngtech.configbuilder.annotation.valueextractor.CommandLineValue;
 import com.tngtech.configbuilder.annotation.valueextractor.CommandLineValueDescriptor;
 import com.tngtech.configbuilder.configuration.ErrorMessageSetup;
-import com.tngtech.configbuilder.exception.ConfigBuilderException;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
@@ -88,14 +87,6 @@ public class CommandLineHelperTest {
         assertThat(sortedOptions.get(1).getLongOpt()).isEqualTo("vir");
         assertThat(sortedOptions.get(1).getOpt()).isEqualTo("v");
         assertThat(sortedOptions.get(1).isRequired()).isEqualTo(false);
-    }
-
-    @Test(expected = ConfigBuilderException.class)
-    public void testGetCommandLineThrowsException() {
-        when(configBuilderFactory.createInstance(DefaultParser.class)).thenReturn(new DefaultParser());
-        when(configBuilderFactory.createInstance(Options.class)).thenReturn(new Options());
-        args = new String[]{"nd", "notDefined"};
-        commandLineHelper.getCommandLine(TestConfig.class, args);
     }
 
     @Test


### PR DESCRIPTION
New method annotation `CommandLineValueDescriptor`, which allows it to generate description strings for command line options at runtime. This can be used, e.g., for
-  localized descriptions or
-  including a list of all possible values of an enum parameter into its description