### PR TITLE
test: update OWASP checker and remove Java 10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java-version: [8, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
+        java-version: [8, 11, 12, 13, 14, 15, 16, 17, 18, 19]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>7.4.0</version>
+                <version>7.4.1</version>
                 <configuration>
                     <failBuildOnCVSS>5</failBuildOnCVSS>
                 </configuration>
@@ -182,7 +182,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>4.9.0</version>
+            <version>4.10.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -239,7 +239,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
-        <slf4j.version>2.0.5</slf4j.version>
+        <slf4j.version>2.0.6</slf4j.version>
     </properties>
 
 </project>


### PR DESCRIPTION
* OWASP 7.4.0 reports a false positive on commons-cli
* Java 10 tests fail with a message regarding compiler bugs. As Java 10 is superseded by 11 in every way that matters, remove it from the JDK list
* Update other dependencies while at it

Signed-off-by: Jan Thiart <jan.thiart@tngtech.com>